### PR TITLE
Changed public key to authorized key format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## 0.9.1: Changed public key to authorized key format (December 5, 2020)
+
+This release changes the `publicKeyBase64` field to `publicKey` and the format from the OpenSSH wire format to the authorized_keys format.
+
+This also means that the internal API format changes from `[]byte` to `string`.
+
+Transitioning to the authorized_keys format should make it easier for auth server implementers to authenticate against SSH keys.  
+
+## 0.9.0: Initial release (December 5, 2020)
+
+This is the initial release of this library and port from ContainerSSH 0.3.0.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ type myHandler struct {
 func (h *myHandler) OnPassword(
     Username string,
     RemoteAddress string,
-    SessionID string,
+    ConnectionID string,
     Password []byte,
 ) (bool, error) {
     if Username == "foo" && string(Password) == "bar" {
@@ -93,14 +93,14 @@ client := auth.NewHttpAuthClient(
 success, err := client.Password(
     "foo",
     []byte("bar"),
-    []byte("asdf"),
+    "0123456789ABCDEF",
     ip
 ) (bool, error)
 
 success, err := client.PubKey(
     "foo",
-    []byte("bar"),
-    []byte("ssh-rsa ..."),
+    "ssh-rsa ...",
+    "0123456789ABCDEF",
     ip
 ) (bool, error)
 ```

--- a/client.go
+++ b/client.go
@@ -20,7 +20,7 @@ type Client interface {
 	// or not. If an error happened while contacting the authentication server it will return an error.
 	PubKey(
 		username string,
-		pubKey []byte,
+		pubKey string,
 		connectionID string,
 		remoteAddr net.IP,
 	) (bool, error)

--- a/client_impl.go
+++ b/client_impl.go
@@ -35,7 +35,7 @@ func (client *httpAuthClient) Password(
 
 func (client *httpAuthClient) PubKey(
 	username string,
-	pubKey []byte,
+	pubKey string,
 	connectionID string,
 	remoteAddr net.IP,
 ) (bool, error) {

--- a/handler.go
+++ b/handler.go
@@ -21,7 +21,7 @@ type Handler interface {
 	// OnPubKey is called when the client requests a public key authentication.
 	//
 	// - Username is the username the user entered.
-	// - PublicKey is the public key of the user in OpenSSH wire format.
+	// - PublicKey is the public key of the user in the authorized key format.
 	// - RemoteAddress is the IP address of the user.
 	// - SessionID is an opaque identifier for the current session.
 	//
@@ -30,7 +30,7 @@ type Handler interface {
 	// a HTTP 500 response.
 	OnPubKey(
 		Username string,
-		PublicKey []byte,
+		PublicKey string,
 		RemoteAddress string,
 		ConnectionID string,
 	) (bool, error)

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,7 +1,6 @@
 package auth_test
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"net"
@@ -40,14 +39,14 @@ func (h *handler) OnPassword(
 	return false, nil
 }
 
-func (h *handler) OnPubKey(Username string, PublicKey []byte, RemoteAddress string, ConnectionID string) (bool, error) {
+func (h *handler) OnPubKey(Username string, PublicKey string, RemoteAddress string, ConnectionID string) (bool, error) {
 	if RemoteAddress != "127.0.0.1" {
 		return false, fmt.Errorf("invalid IP: %s", RemoteAddress)
 	}
 	if ConnectionID != "0123456789ABCDEF" {
 		return false, fmt.Errorf("invalid session ID: %s", ConnectionID)
 	}
-	if Username == "foo" && bytes.Equal(PublicKey, []byte("ssh-rsa asdf")) {
+	if Username == "foo" && PublicKey == "ssh-rsa asdf" {
 		return true, nil
 	}
 	if Username == "crash" {
@@ -77,15 +76,15 @@ func TestAuth(t *testing.T) {
 	assert.NotEqual(t, nil, err)
 	assert.Equal(t, false, success)
 
-	success, err = client.PubKey("foo", []byte("ssh-rsa asdf"), "0123456789ABCDEF", net.ParseIP("127.0.0.1"))
+	success, err = client.PubKey("foo", "ssh-rsa asdf", "0123456789ABCDEF", net.ParseIP("127.0.0.1"))
 	assert.Equal(t, nil, err)
 	assert.Equal(t, true, success)
 
-	success, err = client.PubKey("foo", []byte("ssh-rsa asdx"), "0123456789ABCDEF", net.ParseIP("127.0.0.1"))
+	success, err = client.PubKey("foo", "ssh-rsa asdx", "0123456789ABCDEF", net.ParseIP("127.0.0.1"))
 	assert.Equal(t, nil, err)
 	assert.Equal(t, false, success)
 
-	success, err = client.PubKey("crash", []byte("ssh-rsa asdx"), "0123456789ABCDEF", net.ParseIP("127.0.0.1"))
+	success, err = client.PubKey("crash", "ssh-rsa asdx", "0123456789ABCDEF", net.ParseIP("127.0.0.1"))
 	assert.NotEqual(t, nil, err)
 	assert.Equal(t, false, success)
 }

--- a/protocol.go
+++ b/protocol.go
@@ -54,10 +54,10 @@ type PublicKeyAuthRequest struct {
 	// required: true
 	SessionID string `json:"sessionId"`
 
-	// PublicKey is a serialized key data in SSH wire format.
+	// PublicKey is the key in the authorized key format.
 	//
 	// required: true
-	PublicKey []byte `json:"publicKeyBase64"`
+	PublicKey string `json:"publicKey"`
 }
 
 // ResponseBody is a response to authentication requests.


### PR DESCRIPTION
This release changes the `publicKeyBase64` field to `publicKey` and the format from the OpenSSH wire format to the authorized_keys format.

This also means that the internal API format changes from `[]byte` to `string`.

Transitioning to the authorized_keys format should make it easier for auth server implementers to authenticate against SSH keys.