### PR TITLE
Fixes Auth client doesn't send the connectionId

### DIFF
--- a/client_impl.go
+++ b/client_impl.go
@@ -36,6 +36,7 @@ func (client *httpAuthClient) Password(
 	authRequest := PasswordAuthRequest{
 		Username:      username,
 		RemoteAddress: remoteAddr.String(),
+		ConnectionID:  connectionID,
 		SessionID:     connectionID,
 		Password:      password,
 	}
@@ -53,6 +54,7 @@ func (client *httpAuthClient) PubKey(
 	authRequest := PublicKeyAuthRequest{
 		Username:      username,
 		RemoteAddress: remoteAddr.String(),
+		ConnectionID:  connectionID,
 		SessionID:     connectionID,
 		PublicKey:     pubKey,
 	}

--- a/handler_impl.go
+++ b/handler_impl.go
@@ -37,7 +37,7 @@ func (p *passwordHandler) OnRequest(request http.ServerRequest, response http.Se
 		requestObject.Username,
 		requestObject.Password,
 		requestObject.RemoteAddress,
-		requestObject.SessionID,
+		requestObject.ConnectionID,
 	)
 	if err != nil {
 		p.logger.Warningf("failed to execute password request (%v)", err)


### PR DESCRIPTION
This PR fixes containerssh/containerss#134 where the auth client wouldn't send the connectionId, only the sessionId