### PR TITLE
Fix standard gp http server example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ You can also use the authentication handler with the native Go HTTP library:
 func main() {
     logger := log.New(...)
     httpHandler := auth.NewHandler(&myHandler{}, logger)
-    http.HandleFunc("/auth", httpHandler)
+    http.Handle("/auth", httpHandler)
     http.ListenAndServe(":8090", nil)
 }
 ```


### PR DESCRIPTION
## Please describe the change you are making
Current code fails to compile with the following error:
`cannot use httpHandler (variable of type http.Handler) as func(http.ResponseWriter, *http.Request) value in argument to http.HandleFunc`
Using `http.Handle` fixes the issue. It expects the provided interface implementation from the library.

## Are you the owner of the code you are sending in, or do you have permission of the owner?
Owner

## The code will be published under the MIT-0 license. Have you read and understood this license?

Yes
